### PR TITLE
Adds context to UI text to improve translation into Latin languages

### DIFF
--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -525,7 +525,7 @@ void gui_init(dt_lib_module_t *self)
                                            _("synchronize the image's XMP and remove the local copy"), 0, 0);
   gtk_grid_attach(grid, d->uncache_button, 2, line++, 2, 1);
 
-  d->group_button = dt_action_button_new(self, N_("group"), button_clicked, GINT_TO_POINTER(10),
+  d->group_button = dt_action_button_new(self, C_("selected images action", "group"), button_clicked, GINT_TO_POINTER(10),
                                          _("add selected images to expanded group or create a new one"),
                                          GDK_KEY_g, GDK_CONTROL_MASK);
   gtk_grid_attach(grid, d->group_button, 0, line, 2, 1);


### PR DESCRIPTION
The UI text "group" appears in two contexts in the darktable interface. In the first it is a verb and in the second it is a noun. In English, there is no change in the spelling of the word. However, in Latin languages (such as Portuguese) the verb is hardly spelled in the same way as the corresponding noun. By adding a context, it will be possible for translators to perform a more accurate translation of the interface.